### PR TITLE
Tempdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ pdftk.configure({
     bin: '/your/path/to/pdftk/bin',
     Promise: require('bluebird'),
     ignoreWarnings: true,
+    tempDir: path.join(__dirname, './your/custom/temp/dir')
 });
 ```
 
@@ -97,7 +98,7 @@ Name | Description | Type | Default Value
 bin | Path to your PdfTk executable | String | 'pdftk'
 Promise | Promise library to implement | Object | Promise
 ignoreWarnings | Ignore PdfTk warnings. Useful with huge PDF files | Boolean | False
-tempDir | changes the directory where temporary files are stored | String | libPath + './node-pdftk-tmp/')
+tempDir | Changes the directory where temporary files are stored. MUST BE ABSOLUTE PATH. Use the [path](https://nodejs.org/docs/latest/api/path.html) module. | String | libPath + './node-pdftk-tmp/')
 
 ## Configuring your PdfTk path ##
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ class PdfTk {
              * @member
              * @type {String}
              */
-            this._tempDir = this._tempDir || path.join(__dirname,'./node-pdftk-tmp/');
+            this._tempDir = this._tempDir || path.join(__dirname, './node-pdftk-tmp/');
+
 
             const input = [];
 
@@ -65,9 +66,9 @@ class PdfTk {
              * @returns {String} Path of the newly created temp file.
              */
             const writeTempFile = srcFile => {
-                const tmpPath = path.join(__dirname, this._tempDir);
+                const tmpPath = this._tempDir;
                 const uniqueId = crypto.randomBytes(16).toString('hex');
-                const tmpFile = `${tmpPath}${uniqueId}.pdf`;
+                const tmpFile = path.normalize(`${tmpPath}/${uniqueId}.pdf`);
                 fs.writeFileSync(tmpFile, srcFile);
                 this.tmpFiles.push(tmpFile);
                 return tmpFile;
@@ -1095,9 +1096,9 @@ module.exports = {
                 writable: true,
             },
             _tempDir: {
-               value: options.tempDir,
-               writable: true,
-           },
+                value: options.tempDir,
+                writable: true,
+            },
         });
     },
 };

--- a/test/options.tempDir.spec.js
+++ b/test/options.tempDir.spec.js
@@ -1,0 +1,48 @@
+/* globals describe, it, before, after */
+const chai = require('chai');
+
+const { expect, } = chai;
+
+const pdftk = require('../');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+describe('option - tempDir', function () {
+
+    const tempDir = path.join(__dirname, 'my-tmp-dir');
+
+    before(function () {
+        fs.mkdirSync(tempDir);
+    });
+
+    after(function () {
+        rimraf(tempDir, function () { });
+    });
+
+    it('should use a custom temp directory', function () {
+
+        pdftk.configure({
+            tempDir,
+        });
+
+        // Need to pass in buffer in order to force temp file to be written
+        const input = fs.readFileSync(path.join(__dirname, './files/form.pdf'));
+
+        return pdftk
+            .input(input)
+            .fillForm({
+                name: 'John Doe',
+                email: 'test@email.com',
+            })
+            .output()
+            .then(buffer => expect(buffer).to.not.be.null)
+            .then(() => {
+                pdftk.configure({
+                    tempDir: path.join(__dirname, '../node-pdftk-tmp/'),
+                });
+            })
+            .catch(err => expect(err).to.be.null);
+    });
+
+});


### PR DESCRIPTION
Had to remove the path.join from writeTempFile function. Path will break when an absolute path is passed in. I think the best way to handle this option is to require an absolute path (easy to do with the path module). There really isn't a better way I know of to resolve the path correctly. I also added a path.normalize right before the temp file is created - helps to resolve any weirdness with the path separators.

I also added a test - I've been trying to get more test in when I can. Please test the new changes on your Lamda if you can.

Thanks for the pull request!